### PR TITLE
Add activation hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,5 +66,9 @@
   },
   "scripts": {
     "lint": "eslint src/** --config .eslintrc"
-  }
+  },
+  "activationHooks": [
+    "language-json:grammar-used",
+    "language-json-comments:grammar-used"
+  ]
 }


### PR DESCRIPTION
This delays the activation of the package until the user opens a JSON file and thereby reduces Atoms startup time.
For this package this is actually quite important, since it takes a relative long time to activate it (100-200ms in my case, you can see this in the Timecop view).